### PR TITLE
Add simple login/logout flow

### DIFF
--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -1,0 +1,60 @@
+"use client";
+
+import { useState, useEffect } from "react";
+import { useRouter } from "next/navigation";
+import { useAuth } from "@/hooks/useAuth";
+
+export default function LoginPage() {
+  const router = useRouter();
+  const { loggedIn, login } = useAuth();
+  const [username, setUsername] = useState("");
+  const [password, setPassword] = useState("");
+  const [error, setError] = useState("");
+
+  useEffect(() => {
+    if (loggedIn) {
+      router.push("/");
+    }
+  }, [loggedIn, router]);
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    if (login(username, password)) {
+      router.push("/");
+    } else {
+      setError("Invalid credentials");
+    }
+  };
+
+  return (
+    <div className="min-h-screen flex items-center justify-center p-4 bg-white">
+      <form
+        onSubmit={handleSubmit}
+        className="border-4 border-black p-8 max-w-sm w-full space-y-4"
+      >
+        <h1 className="text-2xl font-black uppercase text-center">Login</h1>
+        <input
+          type="text"
+          value={username}
+          onChange={(e) => setUsername(e.target.value)}
+          placeholder="Username"
+          className="border-2 border-black p-2 w-full"
+        />
+        <input
+          type="password"
+          value={password}
+          onChange={(e) => setPassword(e.target.value)}
+          placeholder="Password"
+          className="border-2 border-black p-2 w-full"
+        />
+        {error && <p className="text-red-600 text-sm">{error}</p>}
+        <button
+          type="submit"
+          className="bg-black text-white border-2 border-black px-4 py-2 w-full"
+        >
+          Login
+        </button>
+      </form>
+    </div>
+  );
+}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -4,15 +4,25 @@ import { useState, useEffect } from "react";
 import { motion, AnimatePresence } from "framer-motion";
 import { VPSConnection } from "@/types/vps";
 import { useWebSocketManager } from "@/hooks/useWebSocketManager";
+import { useAuth } from "@/hooks/useAuth";
+import { useRouter } from "next/navigation";
 import AddVPSModal from "@/components/AddVPSModal";
 import VPSCard from "@/components/VPSCard";
 import ImportExportModal from "@/components/ImportExportModal";
 
 export default function Home() {
+  const { loggedIn, logout } = useAuth();
+  const router = useRouter();
   const [connections, setConnections] = useState<VPSConnection[]>([]);
   const [isModalOpen, setIsModalOpen] = useState(false);
   const [isImportExportModalOpen, setIsImportExportModalOpen] = useState(false);
   const wsConnections = useWebSocketManager(connections);
+
+  useEffect(() => {
+    if (!loggedIn) {
+      router.push("/login");
+    }
+  }, [loggedIn, router]);
 
   // Load connections from localStorage on mount
   useEffect(() => {
@@ -67,6 +77,11 @@ export default function Home() {
     return false;
   };
 
+  const handleLogout = () => {
+    logout();
+    router.push("/login");
+  };
+
   return (
     <main className="min-h-screen bg-white p-0">
       <motion.div 
@@ -113,6 +128,16 @@ export default function Home() {
             whileTap={{ scale: 0.95 }}
           >
             + ADD VPS
+          </motion.button>
+          <motion.button
+            onClick={handleLogout}
+            className="bg-white text-black font-black uppercase px-4 md:px-6 py-3 md:py-4 border-4 border-black hover:bg-black hover:text-white transition-colors w-full md:w-auto"
+            initial={{ scale: 0 }}
+            animate={{ scale: 1 }}
+            transition={{ duration: 0.2, delay: 0.35, ease: "linear" }}
+            whileTap={{ scale: 0.95 }}
+          >
+            LOG OUT
           </motion.button>
         </div>
       </motion.div>

--- a/src/hooks/useAuth.ts
+++ b/src/hooks/useAuth.ts
@@ -1,0 +1,34 @@
+"use client";
+
+import { useState, useEffect } from "react";
+
+const USER = "admin";
+const PASS = "password";
+const STORAGE_KEY = "loggedIn";
+
+export function useAuth() {
+  const [loggedIn, setLoggedIn] = useState(false);
+
+  useEffect(() => {
+    if (typeof window !== "undefined") {
+      const flag = localStorage.getItem(STORAGE_KEY);
+      setLoggedIn(flag === "true");
+    }
+  }, []);
+
+  const login = (username: string, password: string) => {
+    if (username === USER && password === PASS) {
+      localStorage.setItem(STORAGE_KEY, "true");
+      setLoggedIn(true);
+      return true;
+    }
+    return false;
+  };
+
+  const logout = () => {
+    localStorage.removeItem(STORAGE_KEY);
+    setLoggedIn(false);
+  };
+
+  return { loggedIn, login, logout };
+}


### PR DESCRIPTION
## Summary
- create a login page with username/password form
- add `useAuth` hook to manage login flag in `localStorage`
- gate homepage behind login check and add logout button

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_685dd287b6c8832f8c87fcd5e468fef7