### PR TITLE
Use backend storage for VPS connections

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ A brutalist real-time VPS monitoring dashboard built with **Next.js 15** and **R
 
 ## Features
 
-- Manage VPS connections in the browser (persisted via `localStorage`).
+- Manage VPS connections in the browser with server-side persistence.
 - Real-time status updates over WebSocket.
 - Add and remove connections using an animated modal dialog.
 - Responsive layout optimized for desktop and mobile.
@@ -43,7 +43,7 @@ npm start
 
 ## Adding a VPS Connection
 
-Click the **+ ADD VPS** button on the homepage and enter a name and the WebSocket URL of your VPS probe (for example `ws://127.0.0.1:8080/ws`). Metrics are stored locally; no server-side configuration is required.
+Click the **+ ADD VPS** button on the homepage and enter a name and the WebSocket URL of your VPS probe (for example `ws://127.0.0.1:8080/ws`). Connections are stored in the database and linked to your account.
 
 ---
 

--- a/src/components/ImportExportModal.tsx
+++ b/src/components/ImportExportModal.tsx
@@ -100,10 +100,10 @@ export default function ImportExportModal({
                 className="bg-gray-100 border-2 border-black p-4 rounded"
               >
                 <p className="text-xs font-mono uppercase mb-2">
-                  ⚠ NOTE: CONNECTIONS ARE STORED LOCALLY IN YOUR BROWSER
+                  ⚠ NOTE: CONNECTIONS ARE STORED IN YOUR ACCOUNT
                 </p>
                 <p className="text-xs font-mono">
-                  INCOGNITO/PRIVATE WINDOWS HAVE SEPARATE STORAGE
+                  USE EXPORT TO BACK UP OR SHARE THEM
                 </p>
               </motion.div>
 


### PR DESCRIPTION
## Summary
- persist VPS connections via API rather than localStorage
- update import/export modal notice for server storage
- update docs to reflect database persistence

## Testing
- `npm run lint` *(fails: `primaryKey` unused in schema)*

------
https://chatgpt.com/codex/tasks/task_e_685f8303e5d8832fa60e5514f4be6415